### PR TITLE
Add NODE_OPTIONS=--openssl-legacy-provider

### DIFF
--- a/update-webadmin.sh
+++ b/update-webadmin.sh
@@ -25,6 +25,7 @@ docker run --rm -ti \
 	--mount type=bind,source="$(pwd)",target=/app \
 	-w=/app \
 	-u=$UID \
+	-e 'NODE_OPTIONS=--openssl-legacy-provider' \
 	node:lts-alpine \
 	/bin/sh -c "npm install --no-progress && npm run build"
 


### PR DESCRIPTION
To the webadmin build script. New node versions require it, otherwise it dies with `ERR_OSSL_EVP_UNSUPPORTED`. A more proper solution would be to update the webadmin to a newer React version, but that's a lot of work no one has time for currently.