### PR TITLE
Update setup.ubuntu.sh

### DIFF
--- a/setup.ubuntu.sh
+++ b/setup.ubuntu.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-packages=(apache2-utils curl dialog docker.io docker-compose git)
+
+if [[ "$(lsb_release -rs | perl -pe 's/\..+//s')" -gt 20 ]]; then
+    packages=(apache2-utils curl dialog docker.io docker-compose-v2 git)
+else
+    packages=(apache2-utils curl dialog docker.io docker-compose git)
+fi
+
 if [[ $EUID -eq 0 ]]; then
     set -x
     apt update && apt -y install "${packages[@]}"
@@ -7,4 +13,3 @@ else
     set -x
     sudo apt update && sudo apt -y install "${packages[@]}"
 fi
-


### PR DESCRIPTION
Fixed issues with new Ubuntu antics.
Users must still do "docker compose up" instead of "docker-compose up".